### PR TITLE
redisへのアクセスURLを環境変数から取得するように修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,5 +61,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # session
-  config.session_store :redis_store, servers: 'redis://localhost:6379/0/session', expire_in: 30.minutes
+  config.session_store :redis_store, servers: "redis://${REDIS}:6379/0/session", expire_in: 30.minutes
 end


### PR DESCRIPTION
redisへの接続方法を環境変数で取得するように修正

ローカルなら `localhost`で定義して
dockerなら `redis`で定義して

そうするとうまくできるのではないでしょうか。